### PR TITLE
anchor_year plotting now determined by left side of i_interval 1

### DIFF
--- a/lilio/_plot.py
+++ b/lilio/_plot.py
@@ -95,7 +95,7 @@ def generate_plot_data(
     """
     n_targets = calendar.n_targets
 
-    anchor_date = calendar._get_anchor(year=year_intervals.values[-1].left.year)  # type: ignore # pylint: disable=protected-access
+    anchor_date = calendar._get_anchor(year=year_intervals.loc[1].left.year)  # type: ignore # pylint: disable=protected-access
 
     widths = _get_widths(relative_dates, year_intervals)
     interval_str = np.array(


### PR DESCRIPTION
Solves issue #12. 

Minor adjustment to code for determining the y-axis when visualizing the calendar. It was based on the last interval, but I think it should be based on the 'left-side' of the first i_interval (which is generally the anchor_date). However, if a user applies a gap directly to the right side of the anchor_date, this no longer works. Maybe we should prevent that users are able to do this?  