### PR TITLE
Use `pydocstyle` to ensure the docstrings follow the Google convention

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "lilio"
-copyright = "2022, Netherlands eScience Center"
+copyright = "2022, Netherlands eScience Center"  # noqa
 author = "Yang Liu"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/lilio/__init__.py
+++ b/lilio/__init__.py
@@ -1,5 +1,4 @@
-"""
-lilio: Calendar generator for machine learning with timeseries data
+"""lilio: Calendar generator for machine learning with timeseries data.
 
 Time indices are anchored to the target period of interest. By keeping
 observations from the same cycle (typically 1 year) together and paying close

--- a/lilio/_bokeh_plots.py
+++ b/lilio/_bokeh_plots.py
@@ -6,7 +6,7 @@ from ._plot import generate_plot_data
 
 
 def _generate_rectangle(figure: plotting.Figure, source: plotting.ColumnDataSource):
-    """Adds intervals to the figure as rectangles.
+    """Add intervals to the figure as rectangles.
 
     Args:
         figure: Bokeh figure in which the rectangles should be added.

--- a/lilio/_bokeh_plots.py
+++ b/lilio/_bokeh_plots.py
@@ -1,4 +1,4 @@
-"""Calendar plotting implementations (bokeh specific code)"""
+"""Calendar plotting implementations (bokeh specific code)."""
 import sys
 import numpy as np
 from bokeh import plotting
@@ -48,7 +48,6 @@ def _bokeh_visualization(
     Returns:
         plotting.Figure
     """
-
     if add_yticklabels:
         tooltips = [
             ("Interval", "@desc"),
@@ -111,6 +110,17 @@ def bokeh_visualization(
     add_yticklabels: bool = True,
     **kwargs,
 ) -> None:
+    """Visualization routine for generating a calendar visualization with Bokeh.
+
+    Args:
+        calendar: Mapped calendar which should be visualized.
+        n_years: Number of years which should be displayed (most recent years only).
+        relative_dates: If False, absolute dates will be used. If True, each anchor year
+                        is aligned by the anchor date, so that all anchor years line up
+                        vertically.
+        add_yticklabels: If the years should be displayed on the y-axis ticks.
+        **kwargs: Any other kwargs that should be passed to bokeh.plotting.figure()
+    """
     bokeh_fig = _bokeh_visualization(
         calendar, n_years, relative_dates, add_yticklabels, **kwargs
     )

--- a/lilio/_plot.py
+++ b/lilio/_plot.py
@@ -121,7 +121,7 @@ def generate_plot_data(
 
 
 def plot_rectangles(ax: plt.Axes, data: Dict, show_length: bool):
-    """Generates rectangles from the input data.
+    """Generate rectangles from the input data.
 
     Args:
         ax: Axis in which the rectangles should be shown.

--- a/lilio/_plot.py
+++ b/lilio/_plot.py
@@ -1,4 +1,4 @@
-"""Calendar plotting implementations (general and matplotlib)"""
+"""Calendar plotting implementations (general and matplotlib)."""
 from typing import Dict
 import matplotlib.pyplot as plt
 import numpy as np
@@ -163,7 +163,7 @@ def matplotlib_visualization(
     add_yticklabels: bool = True,
     ax=None,
 ):
-    """Visualization routine for generating a calendar visualization with Bokeh.
+    """Visualization routine for generating a calendar visualization with Matplotlib.
 
     Args:
         calendar: Mapped calendar which should be visualized.
@@ -172,7 +172,10 @@ def matplotlib_visualization(
                         is aligned by the anchor date, so that all anchor years line up
                         vertically.
         show_length: If the length of every periods should be displayed. Defaults False.
+        add_legend: Add a legend to the plot. Defaults to True.
         add_yticklabels: If the years should be displayed on the y-axis ticks.
+        ax: If a matplotlib axis object is passed, the plot will be generated in that
+            axis. Otherwise a new figure is generated.
     """
     if ax is None:
         fig, ax = plt.subplots(figsize=(7, 4))

--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -207,12 +207,12 @@ class Calendar:
 
     @property
     def n_targets(self):
-        """Access the number of targets."""
+        """Returns the number of targets."""
         return len(self.targets)
 
     @property
     def anchor(self):
-        """Access the anchor."""
+        """Returns the anchor."""
         return self._anchor
 
     @anchor.setter
@@ -221,7 +221,7 @@ class Calendar:
 
     @property
     def allow_overlap(self):
-        """Access allow overlap."""
+        """Returns the allow_overlap: if overlapping intervals are allowed or not."""
         return self._allow_overlap
 
     @allow_overlap.setter

--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -70,17 +70,17 @@ class Interval:
 
     @property
     def is_target(self):
-        """Returns whether this Intervals is a target interval."""
+        """Return whether this Intervals is a target interval."""
         return self._target
 
     @property
     def role(self):
-        """Returns the type of interval."""
+        """Return the type of interval."""
         return self._role
 
     @property
     def length(self):
-        """Returns the length of the interval, as a pandas.DateOffset."""
+        """Return the length of the interval, as a pandas.DateOffset."""
         return self._length
 
     @length.setter
@@ -95,7 +95,7 @@ class Interval:
 
     @property
     def length_dateoffset(self):
-        """Returns the length property as a dateoffset."""
+        """Return the length property as a dateoffset."""
         return self._length_dateoffset
 
     @property
@@ -207,12 +207,12 @@ class Calendar:
 
     @property
     def n_targets(self):
-        """Returns the number of targets."""
+        """Return the number of targets."""
         return len(self.targets)
 
     @property
     def anchor(self):
-        """Returns the anchor."""
+        """Return the anchor."""
         return self._anchor
 
     @anchor.setter

--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -70,16 +70,17 @@ class Interval:
 
     @property
     def is_target(self):
+        """Returns whether this Intervals is a target interval."""
         return self._target
 
     @property
     def role(self):
-        "Returns the type of interval."
+        """Returns the type of interval."""
         return self._role
 
     @property
     def length(self):
-        "Returns the length of the interval, as a pandas.DateOffset."
+        """Returns the length of the interval, as a pandas.DateOffset."""
         return self._length
 
     @length.setter
@@ -94,6 +95,7 @@ class Interval:
 
     @property
     def length_dateoffset(self):
+        """Returns the length property as a dateoffset."""
         return self._length_dateoffset
 
     @property
@@ -113,6 +115,7 @@ class Interval:
 
     @property
     def gap_dateoffset(self):
+        """Get the gap property as a dateoffset."""
         return self._gap_dateoffset
 
     def __repr__(self):
@@ -204,11 +207,12 @@ class Calendar:
 
     @property
     def n_targets(self):
+        """Access the number of targets."""
         return len(self.targets)
 
     @property
     def anchor(self):
-        "Makes anchor a property so it easier to access."
+        """Access the anchor."""
         return self._anchor
 
     @anchor.setter
@@ -217,6 +221,7 @@ class Calendar:
 
     @property
     def allow_overlap(self):
+        """Access allow overlap."""
         return self._allow_overlap
 
     @allow_overlap.setter
@@ -508,7 +513,7 @@ class Calendar:
             )
 
     def _rename_intervals(self, intervals: pd.DataFrame) -> pd.DataFrame:
-        """Adds target labels to the header row of the intervals.
+        """Add target labels to the header row of the intervals.
 
         Args:
             intervals (pd.Dataframe): Dataframe with intervals.
@@ -516,7 +521,6 @@ class Calendar:
         Returns:
             pd.Dataframe: Dataframe with target periods labelled, sorted by i_interval value.
         """
-
         # rename precursors
         intervals = intervals.rename(
             columns={

--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -29,7 +29,7 @@ class Interval:
         length: Union[str, dict],
         gap: Union[str, dict] = "0d",
     ) -> None:
-        """Constructs the basic element of the calendar.
+        """Construct the basic element of the calendar.
 
         The Interval is characterised by its type (either target or precursor), its
         length and the gap between it and the previous interval of its type (or the
@@ -119,7 +119,7 @@ class Interval:
         return self._gap_dateoffset
 
     def __repr__(self):
-        """String representation of the Interval class."""
+        """Return a string representation of the Interval class."""
         props = [
             ("role", self.role),
             ("length", self.length),
@@ -274,7 +274,7 @@ class Calendar:
             )
 
     def _get_anchor(self, year: int) -> pd.Timestamp:
-        """Method to generate an anchor timestamp for your specific calendar.
+        """Generate an anchor timestamp for your specific calendar.
 
         The method should return the exact timestamp of the end of the anchor_year's
         0 interval, e.g., for the AdventCalendar:
@@ -291,7 +291,7 @@ class Calendar:
         )
 
     def _parse_anchor(self, anchor_str: str) -> Tuple[str, str]:
-        """Parses the user-input anchor.
+        """Parse the user-input anchor.
 
         Args:
             anchor_str: Anchor string in the right formatting.
@@ -333,7 +333,7 @@ class Calendar:
             self.precursors.append(interval)
 
     def _map_year(self, year: int) -> pd.Series:
-        """Internal routine to return a concrete IntervalIndex for the given year.
+        """Return a concrete IntervalIndex for the given year.
 
         Since our calendars are used to study periodic events, they are first
         instantiated without specific year(s). This method adds a specific year
@@ -417,7 +417,7 @@ class Calendar:
         return skip_years
 
     def map_years(self, start: int, end: int):
-        """Adds a start and end year mapping to the calendar.
+        """Add a start and end year mapping to the calendar.
 
         If the start and end years are the same, the intervals for only that single
         year are returned by calendar.get_intervals().
@@ -537,7 +537,7 @@ class Calendar:
         return intervals.sort_index(axis=1)
 
     def get_intervals(self) -> pd.DataFrame:
-        """Method to retrieve updated intervals from the Calendar object."""
+        """Retrieve updated intervals from the Calendar object."""
         if self._mapping is None:
             raise ValueError(
                 "Cannot retrieve intervals without map_years or "
@@ -558,7 +558,7 @@ class Calendar:
         return intervals.sort_index(axis=0, ascending=False)
 
     def show(self) -> pd.DataFrame:
-        """Displays the intervals the Calendar will generate for the current setup.
+        """Display the intervals the Calendar will generate for the current setup.
 
         Returns:
             pd.Dataframe: Dataframe containing the calendar intervals.
@@ -566,7 +566,7 @@ class Calendar:
         return self.get_intervals()
 
     def __repr__(self) -> str:
-        """String representation of the Calendar."""
+        """Return a string representation of the Calendar."""
         intervals = self.targets + self.precursors
         if len(intervals) == 0:
             intervals_str = repr(None)
@@ -605,7 +605,7 @@ class Calendar:
         ax=None,
         **bokeh_kwargs,
     ) -> None:
-        """Plots a visualization of the current calendar setup, to aid in user setup.
+        """Plot a visualization of the current calendar setup, to aid in user setup.
 
         Note: The interactive visualization requires the `bokeh` package to be installed
         in the active Python environment.

--- a/lilio/resampling.py
+++ b/lilio/resampling.py
@@ -80,7 +80,7 @@ def _resample_bins_constructor(
 
 
 def _contains(interval_index: pd.IntervalIndex, timestamps) -> np.ndarray:
-    """Checks elementwise if the intervals contain the timestamps.
+    """Check elementwise if the intervals contain the timestamps.
 
     Will return a boolean array of the shape (n_timestamps, n_intervals).
 
@@ -103,7 +103,7 @@ def _contains(interval_index: pd.IntervalIndex, timestamps) -> np.ndarray:
 
 
 def _create_means_matrix(intervals, timestamps):
-    """Creates a matrix to be used to compute the mean data value of each interval.
+    """Create a matrix to be used to compute the mean data value of each interval.
 
     E.g.: `means = np.dot(matrix, data)`.
 
@@ -121,7 +121,7 @@ def _create_means_matrix(intervals, timestamps):
 def _resample_pandas(
     calendar, input_data: Union[pd.Series, pd.DataFrame]
 ) -> pd.DataFrame:
-    """Internal function to handle resampling of Pandas data.
+    """Resample Pandas data.
 
     Args:
         input_data (pd.Series or pd.DataFrame): Data provided by the user to the
@@ -146,7 +146,7 @@ def _resample_pandas(
 
 # pylint: disable=too-many-locals
 def _resample_dataset(calendar, input_data: xr.Dataset) -> xr.Dataset:
-    """Internal function to handle resampling of xarray data.
+    """Resample xarray data.
 
     Args:
         input_data (xr.DataArray or xr.Dataset): Data provided by the user to the

--- a/lilio/resampling.py
+++ b/lilio/resampling.py
@@ -1,4 +1,4 @@
-"""The implementation of the resampling methods for use with the Calendar"""
+"""The implementation of the resampling methods for use with the Calendar."""
 from typing import Union
 from typing import overload
 import numpy as np
@@ -81,6 +81,7 @@ def _resample_bins_constructor(
 
 def _contains(interval_index: pd.IntervalIndex, timestamps) -> np.ndarray:
     """Checks elementwise if the intervals contain the timestamps.
+
     Will return a boolean array of the shape (n_timestamps, n_intervals).
 
     Args:
@@ -155,7 +156,6 @@ def _resample_dataset(calendar, input_data: xr.Dataset) -> xr.Dataset:
         xr.Dataset: Dataset containing the intervals and data resampled to
             these intervals.
     """
-
     data = calendar.flat.to_xarray().rename("interval")
     data = data.to_dataset()
     data = data.stack(anch_int=("anchor_year", "i_interval"))

--- a/lilio/utils.py
+++ b/lilio/utils.py
@@ -1,4 +1,4 @@
-"""Commonly used utility functions for Lilio"""
+"""Commonly used utility functions for Lilio."""
 import re
 import warnings
 from typing import Dict
@@ -183,7 +183,6 @@ def check_month_day(month: int, day: int = 1):
         month: Month number
         day: Day number. Defaults to 1.
     """
-
     if month in {1, 3, 5, 7, 8, 10, 12}:
         if (day < 1) or (day > 31):
             raise ValueError(
@@ -209,6 +208,7 @@ def check_month_day(month: int, day: int = 1):
 
 
 def check_week_day(week: int, day: int = 1):
+    """Validates the week and day numbers."""
     if week == 53:
         raise ValueError(
             "Incorrect anchor input. "

--- a/lilio/utils.py
+++ b/lilio/utils.py
@@ -14,7 +14,7 @@ XArrayData = (xr.DataArray, xr.Dataset)
 
 def check_timeseries(
     data: Union[pd.Series, pd.DataFrame, xr.DataArray, xr.Dataset]
-    ) -> None:
+) -> None:
     """Check if input data contains valid time data.
 
     Checks if:

--- a/lilio/utils.py
+++ b/lilio/utils.py
@@ -12,8 +12,10 @@ PandasData = (pd.Series, pd.DataFrame)
 XArrayData = (xr.DataArray, xr.Dataset)
 
 
-def check_timeseries(data) -> None:
-    """Utility function to check input data.
+def check_timeseries(
+    data: Union[pd.Series, pd.DataFrame, xr.DataArray, xr.Dataset]
+    ) -> None:
+    """Check if input data contains valid time data.
 
     Checks if:
      - Input data is pd.Dataframe/pd.Series/xr.Dataset/xr.DataArray.
@@ -29,7 +31,7 @@ def check_timeseries(data) -> None:
 
 
 def check_time_dim_xarray(data) -> None:
-    """Utility function to check if xarray data has a time dimensions with time data."""
+    """Check if an xarray data has a time dimensions with time data."""
     if "time" not in data.dims:
         raise ValueError(
             "The input DataArray/Dataset does not contain a `time` dimension"
@@ -45,7 +47,7 @@ def check_time_dim_pandas(data) -> None:
 
 
 def check_empty_intervals(data: Union[pd.DataFrame, xr.Dataset]) -> None:
-    """Utility to check for empty intervals in data.
+    """Check for empty intervals in pandas data.
 
     Note: For the Dataset, all values within a certain interval, anchor_year combination
     have to be NaN, to allow for, e.g., empty gridcells in a latitude/longitude grid.
@@ -78,7 +80,7 @@ def check_empty_intervals(data: Union[pd.DataFrame, xr.Dataset]) -> None:
 
 
 def check_input_frequency(calendar, data):
-    """Checks the frequency of (input) data.
+    """Check the frequency of (input) data.
 
     Note: Pandas and xarray have the builtin function `infer_freq`, but this function is
     not robust enough for our purpose, so we have to manually infer the frequency if the
@@ -107,7 +109,7 @@ def check_input_frequency(calendar, data):
 
 
 def convert_interval_to_bounds(data: xr.Dataset) -> xr.Dataset:
-    """Converts pandas intervals to bounds in a xarray Dataset.
+    """Convert pandas intervals to bounds in a xarray Dataset.
 
     pd.Interval objects cannot be written to netCDF. To allow writing the
     calendar-resampled data to netCDF these intervals have to be converted to bounds.
@@ -139,7 +141,7 @@ def assert_bokeh_available():
 
 
 def get_month_names() -> Dict:
-    """Generates a dictionary with English lowercase month names and abbreviations.
+    """Generate a dictionary with English lowercase month names and abbreviations.
 
     Returns:
         Dictionary containing the English names of the months, including their
@@ -174,7 +176,7 @@ def get_month_names() -> Dict:
 
 
 def check_month_day(month: int, day: int = 1):
-    """Checks if the input day/month combination is valid.
+    """Check if the input day/month combination is valid.
 
     Months must be between 1 and 12, and days must be within 1 and 28/30/31 (depending
     on the month).
@@ -208,7 +210,7 @@ def check_month_day(month: int, day: int = 1):
 
 
 def check_week_day(week: int, day: int = 1):
-    """Validates the week and day numbers."""
+    """Validate the week and day numbers."""
     if week == 53:
         raise ValueError(
             "Incorrect anchor input. "
@@ -225,7 +227,7 @@ def check_week_day(week: int, day: int = 1):
 
 
 def parse_freqstr_to_dateoffset(time_str):
-    """Parses the user-input time strings.
+    """Parse the user-input time strings.
 
     Args:
         time_str: Time length string in the right formatting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ features = ["dev", "bokeh"]
 [tool.hatch.envs.default.scripts]
 lint = [
   "flake8 .",
-  "pydocstye lilio",
+  "pydocstyle lilio",
   "mypy lilio",
   "black --check --diff .",
   "isort --check-only --diff .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ ignore = [
 convention = "google"
 add-select = [
   "D401",  # First line should be in imperative mood
+  "D400",  # First line should end in a period.
+  "D404",  # First word of the docstring should not be 'This'
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ features = ["dev", "bokeh"]
 [tool.hatch.envs.default.scripts]
 lint = [
   "flake8 .",
-  "pydocstye",
+  "pydocstye lilio",
   "mypy lilio",
   "black --check --diff .",
   "isort --check-only --diff .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ ignore = [
 
 [tool.pydocstyle]
 convention = "google"
+add-select = [
+  "D401",  # First line should be in imperative mood
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
   "black",
   "isort",
   "mypy==0.981",
+  "pydocstyle",
   "pytest",
   "pytest-cov",
 ]
@@ -94,6 +95,7 @@ features = ["dev", "bokeh"]
 [tool.hatch.envs.default.scripts]
 lint = [
   "flake8 .",
+  "pydocstye",
   "mypy lilio",
   "black --check --diff .",
   "isort --check-only --diff .",
@@ -142,6 +144,9 @@ ignore = [
   "E501",  # Line length: currently (some) docstrings do not comply.
   "W503",  # https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
 ]
+
+[tool.pydocstyle]
+convention = "google"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
This PR adds `pydocstyle` as an extra linter. All docstrings have also been updated to make sure the CI has a ✔️

Closes #22  