### PR TITLE
Test: moving linting to "ruff"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.egg-info
 *.eggs
 .ipynb_checkpoints
+.mypy_cache
+.ruff_cache
+.venv
 
 build
 dist

--- a/lilio/_bokeh_plots.py
+++ b/lilio/_bokeh_plots.py
@@ -1,8 +1,13 @@
 """Calendar plotting implementations (bokeh specific code)."""
 import sys
+import typing
 import numpy as np
 from bokeh import plotting
 from ._plot import generate_plot_data
+
+
+if typing.TYPE_CHECKING:
+    from lilio.calendar import Calendar
 
 
 def _generate_rectangle(figure: plotting.Figure, source: plotting.ColumnDataSource):
@@ -29,7 +34,7 @@ def _generate_rectangle(figure: plotting.Figure, source: plotting.ColumnDataSour
 
 
 def _bokeh_visualization(
-    calendar,
+    calendar: "Calendar",
     n_years: int,
     relative_dates: bool,
     add_yticklabels: bool = True,
@@ -44,6 +49,7 @@ def _bokeh_visualization(
                         is aligned by the anchor date, so that all anchor years line up
                         vertically.
         add_yticklabels: If the years should be displayed on the y-axis ticks.
+        **kwargs: Keyword arguments that should be passed to Bokeh's plotting.figure.
 
     Returns:
         plotting.Figure

--- a/lilio/_plot.py
+++ b/lilio/_plot.py
@@ -153,8 +153,7 @@ def plot_rectangles(ax: plt.Axes, data: Dict, show_length: bool):
             )
 
 
-# pylint: disable=too-many-arguments
-def matplotlib_visualization(
+def matplotlib_visualization(  # noqa: PLR0913 (too-many-arguments)
     calendar,
     n_years: int,
     relative_dates: bool,

--- a/lilio/_plot.py
+++ b/lilio/_plot.py
@@ -1,4 +1,5 @@
 """Calendar plotting implementations (general and matplotlib)."""
+import typing
 from typing import Dict
 import matplotlib.pyplot as plt
 import numpy as np
@@ -6,6 +7,10 @@ import pandas as pd
 from matplotlib import dates as mdates
 from matplotlib.patches import Patch
 from matplotlib.patches import Rectangle
+
+
+if typing.TYPE_CHECKING:
+    from lilio.calendar import Calendar
 
 
 def make_color_array(n_targets: int, n_intervals: int) -> np.ndarray:
@@ -76,7 +81,7 @@ def _get_widths(
 
 
 def generate_plot_data(
-    calendar,
+    calendar: "Calendar",
     relative_dates: bool,
     year: int,
     year_intervals: pd.Series,
@@ -84,6 +89,7 @@ def generate_plot_data(
     """Util to generate the plotting data, containing all variables to plot.
 
     Args:
+        calendar: The calendar you want to plot.
         relative_dates: If False, absolute dates will be used. If True, each anchor year
                         is aligned by the anchor date, so that all anchor years line up
                         vertically.

--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -594,8 +594,7 @@ class Calendar:
         propstr = f"{linesep}\t" + f",{linesep}\t".join([f"{k}={v}" for k, v in props])
         return f"{self.__class__.__name__}({propstr}{linesep})".replace("\t", "    ")
 
-    #  pylint: disable=too-many-arguments
-    def visualize(
+    def visualize(  # noqa: PLR0913 (too-many-arguments)
         self,
         n_years: int = 3,
         interactive: bool = False,

--- a/lilio/calendar_shifter.py
+++ b/lilio/calendar_shifter.py
@@ -15,6 +15,7 @@ def _gap_shift(
     """Shift a calendar interval's gap property by the given amount.
 
     Args:
+        interval: The interval that will be shifted
         gap: the pandas DateOffset from a calendar interval's `gap` property.
         shift: the shift for the gap, in the form of a pandas-like frequency
             string (e.g. "10d", "2W", or "3M"), or a pandas.DateOffset compatible
@@ -161,17 +162,19 @@ def staggered_calendar(
 def calendar_list_resampler(
     cal_list: list, ds: xr.Dataset, dim_name: str = "step"
 ) -> xr.Dataset:
-    """Resample a dataset to every calendar in a list of calendars.
+    """Return a dataset, resampled to every calendar in a list of calendars.
 
-    The resampled calendars will be concatenated along a dimension (default name 'step')
-    into a single xarray Dataset.
+    The resampled calendars will be concatenated along a new dimension (with the default
+    name 'step') into a single xarray Dataset.
 
     Args:
-        cal_list: list of shifted custom calendars
-        ds: dataset to resample
+        cal_list: List of calendars.
+        ds: Dataset to resample.
+        dim_name: The name of the new dimension that will be added to the output
+            dataset.
 
     Returns:
-        resampled xr.Dataset
+        Resampled xr.Dataset
     """
     ds_r = xr.concat([resample(cal, ds) for cal in cal_list], dim=dim_name)
     ds_r = ds_r.assign_coords({dim_name: ds_r[dim_name].values})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
   "bump2version",
   "hatch",
   "ruff",
+  "isort",
   "black",
   "mypy",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dev = [
   "pydocstyle",
   "pytest",
   "pytest-cov",
+  "ruff",
 ]
 docs = [  # Required for ReadTheDocs
   "myst_parser",
@@ -128,32 +129,41 @@ line-length = 88
 target-version = ['py38', 'py39', 'py310']
 include = '\.pyi?$'
 
-[tool.isort]
-py_version=39
-skip = [".gitignore", ".dockerignore"]
-skip_glob = ["docs/*"]
-force_single_line = true
-lines_after_imports = 2
-no_lines_before = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
-known_first_party = ["lilio"]
-src_paths = ["lilio", "tests"]
-line_length = 120
-
-[tool.flake8]
-max-line-length = 88
-ignore = [
-  "E203",  # Whitespace before ":". Not PEP8 compliant (https://github.com/psf/black/issues/315)
-  "E501",  # Line length: currently (some) docstrings do not comply.
-  "W503",  # https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
+[tool.ruff]
+select = [
+  "E",  # pycodestyle
+  "F",  # pyflakes
+  "B",  # flake8-bugbear
+  "D",  # pydocstyle
+  "C",  # mccabe complexity
+  "I",  # isort
+  "UP",  # pyupgrade (upgrade syntax to current syntax)
 ]
-
-[tool.pydocstyle]
-convention = "google"
-add-select = [
+extend-select = [
   "D401",  # First line should be in imperative mood
   "D400",  # First line should end in a period.
   "D404",  # First word of the docstring should not be 'This'
 ]
+ignore = ["E501"]
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F"]
+unfixable = []
+line-length = 88
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+target-version = "py38"
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
+
+[tool.ruff.isort]
+known-first-party = ["lilio"]
+force-single-line = true
+lines-after-imports = 2
+no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,18 +67,12 @@ dynamic = ["version"]
 dev = [
   "bump2version",
   "hatch",
-  "flake8",
-  "flake8-pyproject",  # Allows flake8 configuration through this file
-  "pyflakes",  # flake8 plugin, checks for errors in code
-  "mccabe",  # flake8 plugin, checks code complexity
-  "pep8-naming",  # flake8 plugin, checks PEP8 naming conventions
+  "ruff",
   "black",
   "isort",
-  "mypy==0.981",
-  "pydocstyle",
+  "mypy",
   "pytest",
   "pytest-cov",
-  "ruff",
 ]
 docs = [  # Required for ReadTheDocs
   "myst_parser",
@@ -135,14 +129,21 @@ select = [
   "D",  # pydocstyle
   "C",  # mccabe complexity
   "I",  # isort
+  "N",  # PEP8-naming
   "UP",  # pyupgrade (upgrade syntax to current syntax)
+  "PLE",  # Pylint error https://github.com/charliermarsh/ruff#error-ple
+  "PLR",  # Pylint refactor (e.g. too-many-arguments)
+  "PLW",  # Pylint warning (useless-else-on-loop)
 ]
 extend-select = [
   "D401",  # First line should be in imperative mood
   "D400",  # First line should end in a period.
   "D404",  # First word of the docstring should not be 'This'
 ]
-ignore = ["E501"]
+ignore = [
+  "E501",  # Line length: fails on many docstrings (needs fixing).
+  "PLR2004",  # magic value used in comparsion (i.e. `if ndays == 28: month_is_feb`).
+]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F"]
 unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,9 @@ features = ["dev", "bokeh"]
 
 [tool.hatch.envs.default.scripts]
 lint = [
-  "flake8 .",
-  "pydocstyle lilio",
+  "ruff check lilio",
   "mypy lilio",
   "black --check --diff .",
-  "isort --check-only --diff .",
 ]
 format = ["isort .", "black .", "lint",]
 test = ["pytest ./lilio/ ./tests/ --doctest-modules",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ dev = [
   "hatch",
   "ruff",
   "black",
-  "isort",
   "mypy",
   "pytest",
   "pytest-cov",
@@ -96,7 +95,7 @@ lint = [
   "mypy lilio",
   "black --check --diff .",
 ]
-format = ["isort .", "black .", "lint",]
+format = ["black .", "lint",]
 test = ["pytest ./lilio/ ./tests/ --doctest-modules",]
 coverage = [
   "pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,10 @@ features = ["dev", "bokeh"]
 lint = [
   "ruff check lilio",
   "mypy lilio",
+  "isort --check-only --diff .",
   "black --check --diff .",
 ]
-format = ["black .", "lint",]
+format = ["isort .", "black .", "lint",]
 test = ["pytest ./lilio/ ./tests/ --doctest-modules",]
 coverage = [
   "pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/",
@@ -127,7 +128,7 @@ select = [
   "B",  # flake8-bugbear
   "D",  # pydocstyle
   "C",  # mccabe complexity
-  "I",  # isort
+#  "I",  # isort (autosort not working correctly, disabled for now).
   "N",  # PEP8-naming
   "UP",  # pyupgrade (upgrade syntax to current syntax)
   "PLE",  # Pylint error https://github.com/charliermarsh/ruff#error-ple
@@ -157,11 +158,23 @@ convention = "google"
 [tool.ruff.mccabe]
 max-complexity = 10
 
-[tool.ruff.isort]
-known-first-party = ["lilio"]
-force-single-line = true
-lines-after-imports = 2
-no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]
+# Configuration for when ruff's import sorting is fixed.
+# [tool.ruff.isort]
+# known-first-party = ["lilio"]
+# force-single-line = true
+# lines-after-imports = 2
+# no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]
+
+[tool.isort]
+py_version=39
+skip = [".gitignore", ".dockerignore"]
+skip_glob = ["docs/*"]
+force_single_line = true
+lines_after_imports = 2
+no_lines_before = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
+known_first_party = ["lilio"]
+src_paths = ["lilio", "tests"]
+line_length = 120
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
[Ruff ](https://github.com/charliermarsh/ruff)is a linter, written in rust, with the aim to reproduce the behavior of most python linters, while being very fast.

In this PR our linter configurations are shifted to ruff, thus removing the need for the flake8, pyflakes, mccabe, pydocstyle & pep8-naming dependencies.

Note: Ruff catches some issues that pydocstyle (https://github.com/AI4S2S/lilio/issues/22) missed.

Reviewer notes:

- Run ruff seperately with `ruff check lilio`. It also runs when calling `hatch run lint`.
- Ruff's automatic import sorting doesn't seem to work properly, it ignores the rules we set. We will need to keep isort for now.
- Tip: install the VS Code ruff extension.