### PR TITLE
0.3.0 release prep

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.3.0
 
 [comment]
 comment = The contents of this file cannot be merged with that of pyproject.toml until https://github.com/c4urself/bump2version/issues/42 is resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ It is named after [the inventor](https://en.wikipedia.org/wiki/Aloysius_Lilius) 
 
 ### Added
 - Resampling now supports many methods (e.g. median, min, std) as well as user-defined functions.
+- A "calendar shifter" to create a list of staggered calendars.
 
 ### Dev changes
 - Lilio makes use of ['hatch'](https://hatch.pypa.io/) now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+
+## 0.3.0 (2022-02-08)
+
+First release of Lilio as a split off from `s2spy`.
+
+Lilio generates calendars to resample timeseries into training and target data for machine learning.
+It is named after [the inventor](https://en.wikipedia.org/wiki/Aloysius_Lilius) of the [Gregorian Calendar](https://en.wikipedia.org/wiki/Gregorian_calendar).
+
+### Fixed
+- Fixed a bug in Matplotlib calendar visualization related to the anchor date.
+
+### Changed
+- The `CustomCalendar` has been renamed to `Calendar`.
+- The `AdventCalendar`, `MonthlyCalendar` and `WeeklyCalendar` have been removed as classes. Instead there are functions that generate a standard `Calendar`.
+
+### Added
+- Resampling now supports many methods (e.g. median, min, std) as well as user-defined functions.
+
+### Dev changes
+- Lilio makes use of ['hatch'](https://hatch.pypa.io/) now.
+  - Building the package has moved to hatchling
+  - Environments and scripts are set up to handle linting and docs building.
+- Ruff is now used as a linter.
+- Notebooks have been moved to the docs folder. Notebooks needs to be cleaned to pass the CI.
+
 ## 0.2.1 (2022-09-02)
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ authors:
     affiliation: "Vrije Universiteit Amsterdam"
 
 date-released: 2022-09-02
-version: "0.2.1"
+version: "0.3.0"
 repository-code: "https://github.com/AI4S2S/lilio"
 keywords:
   - calendar

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = "Yang Liu"
 # built documents.
 #
 # The short X.Y version.
-version = "0.2.1"
+version = "0.3.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/lilio/__init__.py
+++ b/lilio/__init__.py
@@ -76,7 +76,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = "Yang Liu"
 __email__ = "y.liu@esciencecenter.nl"
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 __all__ = [
     "Calendar",


### PR DESCRIPTION
This PR updates the changelog, and bumps the version to 0.3.0