### PR TITLE
Add data attrs to (xarray) resample output

### DIFF
--- a/lilio/__init__.py
+++ b/lilio/__init__.py
@@ -62,8 +62,8 @@ Example:
 """
 
 import logging
-from . import calendar_shifter
-from . import traintest
+from lilio import calendar_shifter
+from lilio import traintest
 from .calendar import Calendar
 from .calendar import Interval
 from .calendar_shorthands import daily_calendar

--- a/lilio/_attrs.py
+++ b/lilio/_attrs.py
@@ -1,9 +1,9 @@
+from datetime import datetime
+from datetime import timezone
 from typing import Union
 import xarray as xr
 import lilio
 from lilio.calendar import Calendar
-from datetime import datetime
-from datetime import timezone
 
 
 def add_attrs(data: Union[xr.DataArray, xr.Dataset], calendar: Calendar) -> None:

--- a/lilio/_attrs.py
+++ b/lilio/_attrs.py
@@ -1,0 +1,40 @@
+from typing import Union
+import xarray as xr
+import lilio
+from lilio.calendar import Calendar
+
+
+def add_attrs(data: Union[xr.DataArray, xr.Dataset], calendar: Calendar) -> None:
+    """Update resampled xarray data with the Calendar's attributes and provenance."""
+    data.attrs = {
+        **data.attrs,  # Keep original attrs
+        "lilio_version": lilio.__version__,
+        "lilio_calendar_anchor_date": calendar.anchor,
+        "lilio_calendar_code": str(calendar),
+    }
+    data["anchor_year"].attrs = {
+        "name": "anchor year",
+        "units": "year",
+        "description": (
+            "The anchor date is the start of the period you want to forecast, and is "
+            "an abstract date and does not include a year. "
+            "Anchor years are used to create a full date with the anchor date "
+            f"(here: {calendar.anchor})."
+        ),
+    }
+    data["i_interval"].attrs = {
+        "name": "interval index",
+        "units": "-",
+        "description": (
+            "The index of each Lilio Calendar interval. Positive values denote "
+            "intervals after the anchor date, while negative values represent intervals"
+            " before the anchor date."
+        ),
+    }
+    data["is_target"].attrs = {
+        "name": "Target flag",
+        "description": (
+            "Denotes if an interval was marked as a target interval in the"
+            " Lilio Calendar."
+        ),
+    }

--- a/lilio/_attrs.py
+++ b/lilio/_attrs.py
@@ -2,16 +2,28 @@ from typing import Union
 import xarray as xr
 import lilio
 from lilio.calendar import Calendar
+from datetime import datetime
+from datetime import timezone
 
 
 def add_attrs(data: Union[xr.DataArray, xr.Dataset], calendar: Calendar) -> None:
     """Update resampled xarray data with the Calendar's attributes and provenance."""
+    history = (
+        f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M:%S %Z} - "
+        "Resampled with a Lilio calendar. "
+        "See: https://github.com/AI4S2S/lilio\n"
+    )
+    if "history" in data.attrs.keys():
+        history += data.attrs["history"]
+
     data.attrs = {
         **data.attrs,  # Keep original attrs. Conflicts will be overwritten attrs below:
         "lilio_version": lilio.__version__,
         "lilio_calendar_anchor_date": calendar.anchor,
         "lilio_calendar_code": str(calendar),
+        "history": history,
     }
+
     data["anchor_year"].attrs = {
         "name": "anchor year",
         "units": "year",

--- a/lilio/_attrs.py
+++ b/lilio/_attrs.py
@@ -7,7 +7,7 @@ from lilio.calendar import Calendar
 def add_attrs(data: Union[xr.DataArray, xr.Dataset], calendar: Calendar) -> None:
     """Update resampled xarray data with the Calendar's attributes and provenance."""
     data.attrs = {
-        **data.attrs,  # Keep original attrs
+        **data.attrs,  # Keep original attrs. Conflicts will be overwritten attrs below:
         "lilio_version": lilio.__version__,
         "lilio_calendar_anchor_date": calendar.anchor,
         "lilio_calendar_code": str(calendar),

--- a/lilio/_attrs.py
+++ b/lilio/_attrs.py
@@ -39,8 +39,8 @@ def add_attrs(data: Union[xr.DataArray, xr.Dataset], calendar: Calendar) -> None
         "units": "-",
         "description": (
             "The index of each Lilio Calendar interval. Positive values denote "
-            "intervals after the anchor date, while negative values represent intervals"
-            " before the anchor date."
+            "intervals after the anchor date (targets), while negative values "
+            "represent intervals before the anchor date (precursors)."
         ),
     }
     data["is_target"].attrs = {

--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -10,8 +10,8 @@ from typing import Union
 import pandas as pd
 import xarray as xr
 from pandas.tseries.offsets import DateOffset
-from . import _plot
-from . import utils
+from lilio import _plot
+from lilio import utils
 
 
 _MappingYears = Tuple[Literal["years"], int, int]

--- a/lilio/calendar_shifter.py
+++ b/lilio/calendar_shifter.py
@@ -4,8 +4,8 @@ from typing import Dict
 from typing import List
 from typing import Union
 import xarray as xr
-from . import calendar
-from . import utils
+from lilio import calendar
+from lilio import utils
 from .resampling import resample
 
 

--- a/lilio/resampling.py
+++ b/lilio/resampling.py
@@ -7,8 +7,9 @@ from typing import overload
 import numpy as np
 import pandas as pd
 import xarray as xr
+from lilio import utils
+from lilio._attrs import add_attrs
 from lilio.calendar import Calendar
-from . import utils
 
 
 # List of numpy statistical methods, with a single input argument and a single output.
@@ -356,5 +357,9 @@ def resample(
     resampled_data = _mark_target_period(resampled_data)
 
     if isinstance(input_data, xr.DataArray):
-        return resampled_data[da_name]
+        resampled_dataarray = resampled_data[da_name]
+        add_attrs(resampled_dataarray, calendar)
+        return resampled_dataarray
+    if isinstance(input_data, xr.Dataset):
+        add_attrs(resampled_data, calendar)
     return resampled_data

--- a/lilio/resampling.py
+++ b/lilio/resampling.py
@@ -358,8 +358,10 @@ def resample(
 
     if isinstance(input_data, xr.DataArray):
         resampled_dataarray = resampled_data[da_name]
+        resampled_dataarray.attrs = input_data.attrs
         add_attrs(resampled_dataarray, calendar)
         return resampled_dataarray
     if isinstance(input_data, xr.Dataset):
+        resampled_data.attrs = input_data.attrs
         add_attrs(resampled_data, calendar)
     return resampled_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ select = [
   "F",  # pyflakes
   "B",  # flake8-bugbear
   "D",  # pydocstyle
-  "C",  # mccabe complexity
+  "C90",  # mccabe complexity
 #  "I",  # isort (autosort not working correctly, disabled for now).
   "N",  # PEP8-naming
   "UP",  # pyupgrade (upgrade syntax to current syntax)
@@ -140,12 +140,13 @@ extend-select = [
   "D401",  # First line should be in imperative mood
   "D400",  # First line should end in a period.
   "D404",  # First word of the docstring should not be 'This'
+  "TID252",  # No relative imports (not pep8 compliant)
 ]
 ignore = [
   "PLR2004",  # magic value used in comparsion (i.e. `if ndays == 28: month_is_feb`).
 ]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F"]
+fixable = ["A", "B", "C90", "D", "E", "F", "TID252"]
 unfixable = []
 line-length = 88
 exclude = ["docs", "build"]

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -211,15 +211,14 @@ class TestResample:
 
     def test_dataset_attrs(self, dummy_calendar, dummy_dataset):
         dataset, _ = dummy_dataset
-        dataset.attrs = {
-            "history": "test_history",
-            "other_attrs": "abc"
-        }
+        dataset.attrs = {"history": "test_history", "other_attrs": "abc"}
         cal = dummy_calendar.map_years(2020, 2025)
         resampled = resample(cal, dataset)
 
         expected_attrs = [
-            "lilio_version", "lilio_calendar_anchor_date", "lilio_calendar_code"
+            "lilio_version",
+            "lilio_calendar_anchor_date",
+            "lilio_calendar_code",
         ]
 
         assert "test_history" in resampled.attrs["history"]
@@ -234,15 +233,14 @@ class TestResample:
         could solve this.
         """
         dataarray, _ = dummy_dataarray
-        dataarray.attrs = {
-            "history": "test_history",
-            "other_attrs": "abc"
-        }
+        dataarray.attrs = {"history": "test_history", "other_attrs": "abc"}
         cal = dummy_calendar.map_years(2020, 2025)
         resampled = resample(cal, dataarray)
 
         expected_attrs = [
-            "lilio_version", "lilio_calendar_anchor_date", "lilio_calendar_code"
+            "lilio_version",
+            "lilio_calendar_anchor_date",
+            "lilio_calendar_code",
         ]
 
         assert "test_history" in resampled.attrs["history"]

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -209,6 +209,47 @@ class TestResample:
         with pytest.warns(UserWarning):
             resample(cal, dataset)
 
+    def test_dataset_attrs(self, dummy_calendar, dummy_dataset):
+        dataset, _ = dummy_dataset
+        dataset.attrs = {
+            "history": "test_history",
+            "other_attrs": "abc"
+        }
+        cal = dummy_calendar.map_years(2020, 2025)
+        resampled = resample(cal, dataset)
+
+        expected_attrs = [
+            "lilio_version", "lilio_calendar_anchor_date", "lilio_calendar_code"
+        ]
+
+        assert "test_history" in resampled.attrs["history"]
+        assert "other_attrs" in resampled.attrs.keys()
+        for att in expected_attrs:
+            assert att in resampled.attrs.keys()
+
+    def test_dataarray_attrs(self, dummy_calendar, dummy_dataarray):
+        """This is a copy of the previous test, but with dataarray input.
+
+        Sadly, fixtures aren't compatible with parameterize. Refactoring the fixtures
+        could solve this.
+        """
+        dataarray, _ = dummy_dataarray
+        dataarray.attrs = {
+            "history": "test_history",
+            "other_attrs": "abc"
+        }
+        cal = dummy_calendar.map_years(2020, 2025)
+        resampled = resample(cal, dataarray)
+
+        expected_attrs = [
+            "lilio_version", "lilio_calendar_anchor_date", "lilio_calendar_code"
+        ]
+
+        assert "test_history" in resampled.attrs["history"]
+        assert "other_attrs" in resampled.attrs.keys()
+        for att in expected_attrs:
+            assert att in resampled.attrs.keys()
+
 
 TOO_LOW_FREQ_ERR = r".*lower time resolution than the calendar.*"
 TOO_LOW_FREQ_WARN = r".*input data frequency is very close to the Calendar's freq.*"


### PR DESCRIPTION
Closes #40

Several attributes are added to the xarray-data output of `resample`, for both clarity and provenance. 