### PR TITLE
Make resample lazy (when a dask array is passed)

### DIFF
--- a/docs/dask_integration.md
+++ b/docs/dask_integration.md
@@ -62,7 +62,7 @@ data_resampled = lilio.resample(calendar, ds)
 Note that this will (quite quickly) return a lazy Dataset: the computation has not been performed yet.
 To compute the result do:
 ```python
-data_resampled.compute()
+data_resampled_results = data_resampled.compute()
 ```
 While this is going on, have a look at the dashboard to see the workers being busy!
 

--- a/docs/dask_integration.md
+++ b/docs/dask_integration.md
@@ -58,4 +58,12 @@ Now your `Dataset` consists of Dask arrays, and the client has been set up, all 
 ```python
 data_resampled = lilio.resample(calendar, ds)
 ```
+
+Note that this will (quite quickly) return a lazy Dataset: the computation has not been performed yet.
+To compute the result do:
+```python
+data_resampled.compute()
+```
 While this is going on, have a look at the dashboard to see the workers being busy!
+
+You can also select certain anchor years, or spatial regions, before you compute, if the full resampled data does not fit into memory.


### PR DESCRIPTION
While optimized with dask, `lilio.resample` still returned a computed object.

The underlying issue turned out to be that the empty-interval check was performed on the resampled data, which checked for NaNs in the resampled variables. This needs them to be computed. It also is quite inefficient: we know how many samples each i_interval has.

Therefore the check has been moved to an earlier stage, and modified to check the list of indices (indices corresponding to each interval).

This removes any RAM limitations, and allows datasets of any size to be resampled, as they can be computed and written to disk chunk by chunk.