### PR TITLE
Add check for empty calendar in resample

### DIFF
--- a/lilio/calendar.py
+++ b/lilio/calendar.py
@@ -206,9 +206,14 @@ class Calendar:
         self._set_mapping(mapping)
 
     @property
-    def n_targets(self):
+    def n_targets(self) -> int:
         """Return the number of targets."""
         return len(self.targets)
+
+    @property
+    def n_precursors(self) -> int:
+        """Return the number of precursors."""
+        return len(self.precursors)
 
     @property
     def anchor(self):

--- a/lilio/resampling.py
+++ b/lilio/resampling.py
@@ -335,6 +335,8 @@ def resample(
     """
     if calendar.mapping is None:
         raise ValueError("Generate a calendar map before calling resample")
+    if calendar.n_targets + calendar.n_precursors == 0:
+        raise ValueError("The calendar has no intervals: resampling is not possible.")
 
     if isinstance(how, str):
         _check_valid_resampling_methods(how)

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -326,6 +326,24 @@ class TestResampleChecks:
         with pytest.raises(ValueError, match=r".*reserved names..*"):
             resample(cal, dummy_dataframe.rename(columns={"data1": "anchor_year"}))
 
+    def test_empty_calendar(self, dummy_dataframe):
+        cal = Calendar(anchor="Jan")
+        cal.map_to_data(dummy_dataframe)
+        with pytest.raises(ValueError, match=r".*calendar has no intervals.*"):
+            resample(cal, dummy_dataframe)
+    
+    def test_single_target(self, dummy_dataframe):
+        cal = Calendar(anchor="Jan")
+        cal.add_intervals("target", length="7d")
+        cal.map_to_data(dummy_dataframe)
+        resample(cal, dummy_dataframe)
+
+    def test_single_precursor(self, dummy_dataframe):
+        cal = Calendar(anchor="Jan")
+        cal.add_intervals("precursor", length="7d")
+        cal.map_to_data(dummy_dataframe)
+        resample(cal, dummy_dataframe)
+
 
 class TestResampleMethods:
     """Test alternative resampling methods.

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -331,7 +331,7 @@ class TestResampleChecks:
         cal.map_to_data(dummy_dataframe)
         with pytest.raises(ValueError, match=r".*calendar has no intervals.*"):
             resample(cal, dummy_dataframe)
-    
+
     def test_single_target(self, dummy_dataframe):
         cal = Calendar(anchor="Jan")
         cal.add_intervals("target", length="7d")


### PR DESCRIPTION
Fixes #57 .

- Added check for calendar having any intervals
- Added n_precursors property (for this check, and to align with the `n_targets` property).
- Added tests for an empty calendar, a calendar with just 1 target, and a calendar with just 1 precursor.
